### PR TITLE
Add Security Headers to API with Flask-Talisman

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,29 +1,55 @@
-# Pin dependancies that might cause breakage
-Werkzeug==2.1.2
-SQLAlchemy==1.4.46
-
-# Build dependencies
+astroid==2.11.7
+black==22.3.0
+certifi==2024.8.30
+charset-normalizer==3.4.0
+click==8.1.7
+colorama==0.4.6
+coverage==6.3.2
+defusedxml==0.7.1
+dill==0.3.9
+factory-boy==2.12.0
+Faker==33.1.0
+flake8==4.0.1
 Flask==2.1.2
 Flask-SQLAlchemy==2.5.1
-psycopg2-binary==2.9.3
-python-dotenv==0.20.0
-
-# Runtime dependencies
+flask-talisman==1.1.0
+greenlet==3.1.1
 gunicorn==20.1.0
 honcho==1.1.0
-
-# Code quality
-pylint==2.14.0
-flake8==4.0.1
-black==22.3.0
-
-# Testing dependencies
-nose==1.3.7
-pinocchio==0.4.3
-factory-boy==2.12.0
-
-# Code Coverage
-coverage==6.3.2
-
-# Utilities
 httpie==3.2.1
+idna==3.10
+importlib_metadata==8.5.0
+isort==5.13.2
+itsdangerous==2.2.0
+Jinja2==3.1.4
+lazy-object-proxy==1.10.0
+markdown-it-py==3.0.0
+MarkupSafe==3.0.2
+mccabe==0.6.1
+mdurl==0.1.2
+multidict==6.1.0
+mypy-extensions==1.0.0
+nose==1.3.7
+pathspec==0.12.1
+pinocchio==0.4.3
+platformdirs==4.3.6
+psycopg2-binary==2.9.3
+pycodestyle==2.8.0
+pyflakes==2.4.0
+Pygments==2.18.0
+pylint==2.14.0
+PySocks==1.7.1
+python-dateutil==2.9.0.post0
+python-dotenv==0.20.0
+requests==2.32.3
+requests-toolbelt==1.0.0
+rich==13.9.4
+six==1.17.0
+SQLAlchemy==1.4.46
+tomli==2.2.1
+tomlkit==0.13.2
+typing_extensions==4.12.2
+urllib3==2.2.3
+Werkzeug==2.1.2
+wrapt==1.17.0
+zipp==3.21.0

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -8,10 +8,12 @@ import sys
 from flask import Flask
 from service import config
 from service.common import log_handlers
+from flask_talisman import Talisman
 
 # Create Flask application
 app = Flask(__name__)
 app.config.from_object(config)
+talisman = Talisman(app)
 
 # Import the routes After the Flask app is created
 # pylint: disable=wrong-import-position, cyclic-import, wrong-import-order

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -12,12 +12,33 @@ from tests.factories import AccountFactory
 from service.common import status  # HTTP Status Codes
 from service.models import db, Account, init_db
 from service.routes import app
+from service import talisman
 
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql://postgres:postgres@localhost:5432/postgres"
 )
 
 BASE_URL = "/accounts"
+
+HTTPS_ENVIRON = {'wsgi.url_scheme': 'https'}
+
+class TestSecurityHeaders(TestCase):
+    def setUp(self):
+        """Set up test client"""
+        self.client = app.test_client()
+
+    def test_security_headers(self):
+        """It should return security headers"""
+        response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        headers = {
+            'X-Frame-Options': 'SAMEORIGIN',
+            'X-Content-Type-Options': 'nosniff',
+            'Content-Security-Policy': 'default-src \'self\'; object-src \'none\'',
+            'Referrer-Policy': 'strict-origin-when-cross-origin'
+        }
+        for key, value in headers.items():
+            self.assertEqual(response.headers.get(key), value)
 
 
 ######################################################################
@@ -34,6 +55,7 @@ class TestAccountService(TestCase):
         app.config["SQLALCHEMY_DATABASE_URI"] = DATABASE_URI
         app.logger.setLevel(logging.CRITICAL)
         init_db(app)
+        talisman.force_https = False
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
This pull request adds security headers to the REST API using Flask-Talisman. It includes tests to ensure the correct headers are set and disables forced HTTPS for testing purposes